### PR TITLE
versions of finch-core and finch-circe has been fixed for current availability 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 resolvers += "TM" at "http://maven.twttr.com"
 
 libraryDependencies ++= Seq(
-  "com.github.finagle" %% "finch-core" % "0.9.2-SNAPSHOT" changing(),
-  "com.github.finagle" %% "finch-circe" % "0.9.2-SNAPSHOT" changing(),
+  "com.github.finagle" %% "finch-core" % "0.9.2" changing(),
+  "com.github.finagle" %% "finch-circe" % "0.9.2" changing(),
   "io.circe" %% "circe-generic" % "0.3.0-SNAPSHOT" changing(),
   "com.twitter" %% "twitter-server" % "1.15.0",
   "com.twitter" %% "finagle-stats" % "6.30.0"


### PR DESCRIPTION
Hi, 
i just found that SNAPSHOTS version of  finch-core and finch-circe not available anymore, because of I fixed build.sbt with versions that I found - it's looks like for now it works again, at least for me.
Thanks.
